### PR TITLE
Add persistence, agency updates and visualization

### DIFF
--- a/adjacency_seed.py
+++ b/adjacency_seed.py
@@ -2,9 +2,24 @@ from openai import OpenAI
 import os
 import json
 
+# Load offline adjacency data if available
+OFFLINE_PATH = os.path.join(os.path.dirname(__file__), "offline_adjacency.json")
+_OFFLINE_DATA = {}
+if os.path.exists(OFFLINE_PATH):
+    try:
+        with open(OFFLINE_PATH, "r") as f:
+            _OFFLINE_DATA = json.load(f)
+    except Exception:
+        _OFFLINE_DATA = {}
+
 client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 
 def generate_adjacents(token, top_k=5):
+    """Return a list of adjacent concepts for the given token."""
+    # Check offline data first
+    if token in _OFFLINE_DATA:
+        return _format_adjacents(_OFFLINE_DATA[token][:top_k], source="offline")
+
     try:
         prompt = f"List {top_k} semantically adjacent words or concepts to the term '{token}', in a JSON array."
 
@@ -50,13 +65,13 @@ def generate_adjacents(token, top_k=5):
         print(f"[AdjacencySeed] Error generating adjacents for '{token}': {e}")
         return []
 
-def _format_adjacents(adj_list):
+def _format_adjacents(adj_list, source="GPT-3.5"):
     return [
         {
             "glyph": f"⟁{adj}",
             "token": adj,
             "weight": 1,
-            "source": "GPT-3.5"
+            "source": source,
         }
         for adj in adj_list if isinstance(adj, str)
     ]

--- a/agency_gate.py
+++ b/agency_gate.py
@@ -2,7 +2,7 @@ from datetime import datetime
 import random
 
 # Gate decision logic
-def process_agency_gates(token, token_data):
+def process_agency_gates(token, token_data, adjacency_count=0):
     print(f"[AgencyGate] Processing gates for token: {token}")
 
     # Example gates
@@ -16,8 +16,7 @@ def process_agency_gates(token, token_data):
     for gate in gates:
         # Adjust decision probabilities based on the token's context (e.g., weight, frequency)
         if gate == "explore":
-            # Higher frequency or weight increases the likelihood of exploration
-            explore_weight = 0.5 + (frequency * 0.1)
+            explore_weight = 0.4 + (frequency * 0.1) + (adjacency_count * 0.05)
             explore_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[explore_weight, 0.3, 0.2])[0]
             decisions.append({
                 "gate": gate,
@@ -26,8 +25,8 @@ def process_agency_gates(token, token_data):
             })
         
         elif gate == "reevaluate":
-            # Reevaluate gate has a dynamic chance to trigger based on the weight of the token
-            reevaluate_weight = 0.4 + (weight * 0.15)
+            # Reevaluate gate considers weight and how many adjacencies a token has
+            reevaluate_weight = 0.3 + (weight * 0.15) + (adjacency_count * 0.05)
             reevaluate_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[reevaluate_weight, 0.4, 0.1])[0]
             decisions.append({
                 "gate": gate,
@@ -36,8 +35,7 @@ def process_agency_gates(token, token_data):
             })
 
         elif gate == "externalize":
-            # Externalize gate is more likely to trigger if token is "important"
-            externalize_weight = 0.3 + (weight * 0.25)
+            externalize_weight = 0.2 + (weight * 0.25) + (frequency * 0.05)
             externalize_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[externalize_weight, 0.5, 0.1])[0]
             decisions.append({
                 "gate": gate,
@@ -46,8 +44,7 @@ def process_agency_gates(token, token_data):
             })
 
         elif gate == "prune":
-            # Prune gate will have a higher chance of being triggered if the token has low weight or frequency
-            prune_weight = 0.6 - (weight * 0.1)
+            prune_weight = 0.6 - (weight * 0.1) - (frequency * 0.05)
             prune_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[prune_weight, 0.3, 0.1])[0]
             decisions.append({
                 "gate": gate,

--- a/graph_cli.py
+++ b/graph_cli.py
@@ -1,0 +1,59 @@
+import os
+import argparse
+import json
+import networkx as nx
+import matplotlib.pyplot as plt
+
+from history_tracer import _load_log
+
+LOG_DIR = os.path.join('glyph_memory', 'logs')
+
+def plot_adjacency_graph(output='adjacency_graph.png'):
+    G = nx.DiGraph()
+    entries = _load_log('adjacency_walk.log')
+    for e in entries:
+        src = e.get('from')
+        dst = e.get('to')
+        if src and dst:
+            G.add_edge(src, dst)
+    if not G:
+        print('No adjacency data found')
+        return
+    plt.figure(figsize=(8,6))
+    nx.draw_networkx(G, node_color='lightblue', edge_color='gray', with_labels=True)
+    plt.tight_layout()
+    plt.savefig(output)
+    print(f'Graph saved to {output}')
+
+
+def plot_weight_history(token, output='weight_history.png'):
+    entries = [e for e in _load_log('weight_updates.log') if e.get('token') == token]
+    if not entries:
+        print('No weight history for token')
+        return
+    weights = [e['new_weight'] for e in entries]
+    plt.figure(figsize=(6,4))
+    plt.plot(range(len(weights)), weights, marker='o')
+    plt.title(f'Weight over time for {token}')
+    plt.xlabel('update')
+    plt.ylabel('weight')
+    plt.tight_layout()
+    plt.savefig(output)
+    print(f'History saved to {output}')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Visualize SKG engine history')
+    parser.add_argument('--graph', action='store_true', help='Plot adjacency graph')
+    parser.add_argument('--token', help='Plot weight history for token')
+    parser.add_argument('--out', default=None, help='Output image path')
+    args = parser.parse_args()
+
+    if args.graph:
+        out = args.out or 'adjacency_graph.png'
+        plot_adjacency_graph(out)
+    if args.token:
+        out = args.out or f'{args.token}_weights.png'
+        plot_weight_history(args.token, out)
+    if not args.graph and not args.token:
+        parser.print_help()

--- a/history_tracer.py
+++ b/history_tracer.py
@@ -1,0 +1,53 @@
+import os
+import json
+
+LOG_DIR = os.path.join('glyph_memory', 'logs')
+
+
+def _load_log(filename):
+    path = os.path.join(LOG_DIR, filename)
+    entries = []
+    if not os.path.exists(path):
+        return entries
+    with open(path, 'r') as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return entries
+
+
+def show_weight_history(token=None):
+    """Print weight change history. If token is None, all entries are shown."""
+    entries = _load_log('weight_updates.log')
+    for e in entries:
+        if token is None or e.get('token') == token:
+            print(f"{e.get('timestamp')} {e.get('token')} {e.get('old_weight')} -> {e.get('new_weight')}")
+
+
+def show_adjacency_walks():
+    """Print adjacency transitions in chronological order."""
+    entries = _load_log('adjacency_walk.log')
+    for e in entries:
+        print(f"{e.get('timestamp')} {e.get('from')} -> {e.get('to')} depth={e.get('depth')}")
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Display logged history for SKG engine')
+    parser.add_argument('--token', help='Show weight history for a specific token')
+    parser.add_argument('--adjacencies', action='store_true', help='Show adjacency walk log')
+    args = parser.parse_args()
+
+    if args.adjacencies:
+        show_adjacency_walks()
+    if args.token:
+        show_weight_history(args.token)
+    if not args.token and not args.adjacencies:
+        parser.print_help()
+

--- a/modalities.py
+++ b/modalities.py
@@ -40,6 +40,9 @@ def generate_modalities(token, glyph_id):
     # --- IMAGE SEARCH ---
     fetched_images = fetch_images_from_serpapi(token, glyph_id, max_results=3)
 
+    # --- TEXTUAL/ASCII REPRESENTATION ---
+    ascii_art = f"<{token.upper()}>"
+
     return {
         "text": {
             "weight": 1
@@ -53,5 +56,8 @@ def generate_modalities(token, glyph_id):
             "photographic": fetched_images,
             "symbolic_image": symbolic_image_path,
             "fft_from_image": fft_from_image_path
+        },
+        "extra": {
+            "ascii_art": ascii_art
         }
     }

--- a/offline_adjacency.json
+++ b/offline_adjacency.json
@@ -1,0 +1,7 @@
+{
+  "fire": ["flame", "burn", "heat", "spark", "ember"],
+  "water": ["ocean", "liquid", "river", "flow", "hydrate"],
+  "earth": ["soil", "ground", "stone", "rock", "clay"],
+  "air": ["wind", "breeze", "sky", "oxygen", "atmosphere"],
+  "truth": ["honesty", "fact", "reality", "verity", "accuracy"]
+}

--- a/skg_engine.py
+++ b/skg_engine.py
@@ -1,4 +1,5 @@
 import json
+import os
 from datetime import datetime
 import random
 
@@ -6,11 +7,57 @@ class SKGEngine:
     def __init__(self, memory_path):
         self.memory_path = memory_path
         self.glyph_pool = []  # Holds available glyphs
-        self.token_map = {}  # Maps tokens to glyphs
-        self.adjacency_map = {}  # Maps tokens to their adjacencies (could be semantic or contextual)
+        self.token_map = {}
+        self.adjacency_map = {}
+
+        # Load persisted state if available
+        self._load_state()
+
+        # Setup logging for adjacency walks and weight changes
+        self.log_dir = os.path.join(self.memory_path, "logs")
+        os.makedirs(self.log_dir, exist_ok=True)
+        self.adj_log = os.path.join(self.log_dir, "adjacency_walk.log")
+        self.weight_log = os.path.join(self.log_dir, "weight_updates.log")
+
+    def _state_path(self, name):
+        return os.path.join(self.memory_path, f"{name}.json")
+
+    def _load_state(self):
+        """Load persisted token and adjacency maps if they exist."""
+        for attr in ("token_map", "adjacency_map"):
+            path = self._state_path(attr)
+            if os.path.exists(path):
+                try:
+                    with open(path, "r") as f:
+                        setattr(self, attr, json.load(f))
+                except Exception:
+                    setattr(self, attr, {})
+
+    def save_state(self):
+        """Persist token_map and adjacency_map to disk."""
+        for attr in ("token_map", "adjacency_map"):
+            path = self._state_path(attr)
+            try:
+                with open(path, "w") as f:
+                    json.dump(getattr(self, attr), f, indent=2)
+            except Exception:
+                pass
+
+    def _log(self, path, entry):
+        """Append a JSON entry to a log file."""
+        try:
+            with open(path, "a") as f:
+                f.write(json.dumps(entry) + "\n")
+        except Exception:
+            pass
 
     def update_glyph_weight(self, glyph):
         """Increment symbolic weight for existing glyph or initialize if absent."""
+        if not isinstance(glyph, dict):
+            return glyph
+
+        old_weight = glyph.get("modalities", {}).get("text", {}).get("weight", 0)
+
         if "modalities" in glyph and "text" in glyph["modalities"]:
             if "weight" in glyph["modalities"]["text"]:
                 glyph["modalities"]["text"]["weight"] += 1
@@ -18,8 +65,18 @@ class SKGEngine:
                 glyph["modalities"]["text"]["weight"] = 1
         else:
             glyph.setdefault("modalities", {}).setdefault("text", {})["weight"] = 1
-        
+
+        new_weight = glyph["modalities"]["text"]["weight"]
         glyph["last_updated"] = datetime.utcnow().isoformat() + "Z"
+
+        self._log(self.weight_log, {
+            "timestamp": glyph["last_updated"],
+            "token": glyph.get("token"),
+            "glyph_id": glyph.get("glyph_id"),
+            "old_weight": old_weight,
+            "new_weight": new_weight,
+        })
+
         return glyph
 
     def assign_glyph_to_token(self, token, adjacency=None):
@@ -29,11 +86,21 @@ class SKGEngine:
             glyph = self.token_map[token]
         else:
             # Select an actual symbolic glyph (not the token text)
-            glyph = self.select_glyph_for_token(token, adjacency)
+            glyph_id = self.select_glyph_for_token(token, adjacency)
+            now = datetime.utcnow().isoformat() + "Z"
+            glyph = {
+                "glyph_id": glyph_id,
+                "token": token,
+                "created_on": now,
+                "last_updated": now,
+                "modalities": {"text": {"weight": 0}},
+            }
             self.token_map[token] = glyph
+            self.save_state()
 
         # Update the glyph's weight
         glyph = self.update_glyph_weight(glyph)
+        self.save_state()
         return glyph
 
 
@@ -48,10 +115,13 @@ class SKGEngine:
         """Get the adjacency list for a token. Can be expanded to semantic adjacencies."""
         return self.adjacency_map.get(token, [])
 
-    def recursive_thought_loop(self, token, depth=0, max_depth=5):
-        """Perform a recursive exploration of a token's adjacencies, activating agency gates."""
-        if depth >= max_depth:
+    def recursive_thought_loop(self, token, depth=0, max_depth=5, visited=None):
+        """Perform a recursive exploration of a token's adjacencies while logging the walk."""
+        if visited is None:
+            visited = set()
+        if depth >= max_depth or token in visited:
             return []
+        visited.add(token)
 
         # Assign the glyph for the current token
         current_glyph = self.assign_glyph_to_token(token)
@@ -67,15 +137,38 @@ class SKGEngine:
         result = [current_glyph]
         
         for adjacent_token in adjacencies:
-            result.extend(self.recursive_thought_loop(adjacent_token, depth + 1, max_depth))
+            self._log(self.adj_log, {
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+                "from": token,
+                "to": adjacent_token,
+                "depth": depth,
+            })
+            result.extend(self.recursive_thought_loop(adjacent_token, depth + 1, max_depth, visited))
 
         return result
 
     def evaluate_agency_gate(self, token):
-        """Evaluate which agency gate should be activated based on the token's context."""
-        # For now, a random decision is made (this could be made more sophisticated based on token's state)
-        decisions = ['explore', 'reevaluate', 'externalize', 'prune']
-        return random.choice(decisions)
+        """Evaluate which agency gate should be activated using contextual heuristics."""
+        glyph = self.token_map.get(token, {})
+        weight = glyph.get("modalities", {}).get("text", {}).get("weight", 1)
+        frequency = weight
+        adjacency_count = len(self.adjacency_map.get(token, []))
+
+        token_data = {
+            "frequency": frequency,
+            "weight": weight,
+        }
+
+        from agency_gate import process_agency_gates
+
+        decisions = process_agency_gates(token, token_data, adjacency_count)
+
+        for d in decisions:
+            if d["decision"] == "YES":
+                return d["gate"]
+
+        # default if nothing triggered
+        return random.choice([d["gate"] for d in decisions])
 
     def externalize_token(self, token):
         """Externalize the token's glyph (i.e., generate its output)."""
@@ -85,6 +178,7 @@ class SKGEngine:
     def update_adjacency_map(self, token, adjacencies):
         """Update the adjacency map for a given token."""
         self.adjacency_map[token] = adjacencies
+        self.save_state()
 
     def add_glyph_to_pool(self, glyph):
         """Add a new glyph to the glyph pool."""

--- a/tests/test_adjacency_seed.py
+++ b/tests/test_adjacency_seed.py
@@ -1,0 +1,16 @@
+import unittest
+
+try:
+    from adjacency_seed import generate_adjacents
+except Exception:
+    generate_adjacents = None
+
+class TestAdjacencySeed(unittest.TestCase):
+    def test_offline_data(self):
+        if generate_adjacents is None:
+            self.skipTest('openai module not available')
+        adjs = generate_adjacents('fire')
+        self.assertTrue(any(a['token'] == 'flame' for a in adjs))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_agency_gate.py
+++ b/tests/test_agency_gate.py
@@ -1,0 +1,10 @@
+import unittest
+from agency_gate import process_agency_gates
+
+class TestAgencyGate(unittest.TestCase):
+    def test_decision_structure(self):
+        decisions = process_agency_gates('fire', {'frequency': 2, 'weight': 3}, adjacency_count=1)
+        self.assertTrue(all('gate' in d and 'decision' in d for d in decisions))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,23 @@
+import os
+import json
+import tempfile
+import unittest
+
+from skg_engine import SKGEngine
+
+class TestPersistence(unittest.TestCase):
+    def test_save_and_load(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = SKGEngine(tmp)
+            engine.add_glyph_to_pool('🜂')
+            engine.update_adjacency_map('fire', ['heat'])
+            engine.assign_glyph_to_token('fire')
+            engine.save_state()
+
+            # Create new engine to load state
+            engine2 = SKGEngine(tmp)
+            self.assertIn('fire', engine2.token_map)
+            self.assertIn('fire', engine2.adjacency_map)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add offline fallback for adjacency seeding
- persist token/adacency maps to disk and reload them
- expand agency gate logic with context
- return ascii modality and new graph CLI
- add unit tests for persistence, agency gates and adjacency seeding

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_68409ade2244832d8b9983510e3acfc1