### PR TITLE
Add thought cycle tracker

### DIFF
--- a/_SCRAP-YARD/skg_engine.py
+++ b/_SCRAP-YARD/skg_engine.py
@@ -5,6 +5,7 @@ import json
 import time
 import logging
 import sys
+from skg_thought_tracker import SKGThoughtTracker
 
 from intermodal_linker import update_intermodal_map
 
@@ -73,7 +74,8 @@ class SKGEngine:
         self.stop_requested = False
         self.visualizer = visualizer
         self.gate_data = gate_data
-        self.tu = TokenUtils()
+        self.thought_tracker = SKGThoughtTracker()
+        self.tu = TokenUtils(thought_tracker=self.thought_tracker)
 
         # Initialize input_token_ids before using it
         self.input_token_ids = set()

--- a/skg_thought_tracker.py
+++ b/skg_thought_tracker.py
@@ -1,0 +1,39 @@
+class SKGThoughtTracker:
+    def __init__(self):
+        self.adjacency_deltas = []
+        self.convergence_deltas = []
+        self.thought_loops = []
+        self.expansion_chain = []
+
+    def log_adjacency(self, from_token, to_token, slot, weight_delta=1):
+        self.adjacency_deltas.append({
+            "from": from_token,
+            "to": to_token,
+            "slot": slot,
+            "weight_delta": weight_delta
+        })
+
+    def log_convergence(self, token_list, overlap_count, new_slots_created):
+        self.convergence_deltas.append({
+            "tokens": token_list,
+            "overlaps": overlap_count,
+            "new_slots": new_slots_created
+        })
+
+    def log_thought_loop(self, token, depth, glyphs_visited, externalized):
+        self.thought_loops.append({
+            "token": token,
+            "depth": depth,
+            "glyphs_visited": glyphs_visited,
+            "externalized": externalized
+        })
+
+    def log_expansion(self, source_token, introduced_token, origin_glyph):
+        self.expansion_chain.append({
+            "source": source_token,
+            "new_token": introduced_token,
+            "via_glyph": origin_glyph
+        })
+
+    def reset(self):
+        self.__init__()


### PR DESCRIPTION
## Summary
- implement `SKGThoughtTracker` for recording adjacency, convergence, loops and expansions
- integrate tracker with `skg_engine.py`
- propagate tracker to `_SCRAP-YARD` engine and token utilities
- log symbolic cognition during recursive walks

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841dc595b4c832db32fc1ec3a7dd48e