### PR TITLE
Add voice input and adjacency weighting

### DIFF
--- a/glyph_builder.py
+++ b/glyph_builder.py
@@ -5,12 +5,12 @@ from adjacency_seed import generate_adjacents
 from modalities import generate_modalities
 from glyph_decision_engine import choose_glyph_for_token
 
-def build_glyph_if_needed(token, path):
+def build_glyph_if_needed(token, path, adj_count: int = 50):
     print(f"[GlyphBuilder] Building glyph for unknown token: '{token}'")
     now = datetime.utcnow().isoformat() + "Z"
 
     # Step 1: Generate adjacents first (required for glyph decision)
-    adjacents = generate_adjacents(token)
+    adjacents = generate_adjacents(token, top_k=adj_count)
 
     # Step 2: Choose glyph based on token and adjacents
     glyph_id = choose_glyph_for_token(token, adjacents)

--- a/hlsf_adapter.py
+++ b/hlsf_adapter.py
@@ -1,0 +1,47 @@
+import numpy as np
+from functools import lru_cache
+from typing import Tuple, List
+
+
+def multiplier(level: int, sides: int) -> float:
+    """Scaling multiplier used for nested symmetry calculations."""
+    if sides % 2 == 0:
+        return 2 ** (level - 2)
+    else:
+        return 1.5 ** (level - 2)
+
+
+@lru_cache(maxsize=None)
+def _generate_vertices_impl(center: Tuple[float, float], radius: float, sides: int) -> List[Tuple[float, float]]:
+    angles = np.linspace(0, 2 * np.pi, sides, endpoint=False)
+    x = center[0] + radius * np.sin(angles)
+    y = center[1] + radius * np.cos(angles)
+    return list(zip(x, y))
+
+
+def generate_vertices(center: Tuple[float, float], radius: float, sides: int) -> List[Tuple[float, float]]:
+    if isinstance(center, np.ndarray):
+        center = tuple(center.tolist())
+    return _generate_vertices_impl(center, radius, sides)
+
+
+def midpoint(p1: Tuple[float, float], p2: Tuple[float, float]) -> Tuple[float, float]:
+    return ((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
+
+
+def calculate_symmetry_point_adjusted(center: Tuple[float, float], radius: float, sides: int, level: int) -> np.ndarray:
+    center2d = np.array(center, dtype=float)
+    if level <= 1:
+        return center2d
+
+    cumulative_offset = np.array([0.0, 0.0])
+    for current_level in range(2, level + 1):
+        scaling_factor = multiplier(current_level, sides)
+        current_adjustment = radius * scaling_factor
+        verts = generate_vertices(center2d, current_adjustment, sides)
+        if sides % 2 == 1:
+            current_offset = np.array(midpoint(verts[0], verts[1])) - center2d
+        else:
+            current_offset = np.array(verts[0]) - center2d
+        cumulative_offset += current_offset
+    return center2d + cumulative_offset

--- a/stt_engine.py
+++ b/stt_engine.py
@@ -1,0 +1,27 @@
+import speech_recognition as sr
+
+
+def transcribe_speech(timeout=5, phrase_time_limit=5):
+    """Capture audio from the default microphone and return recognized text."""
+    recognizer = sr.Recognizer()
+    try:
+        with sr.Microphone() as source:
+            print("[STT] Listening...")
+            audio = recognizer.listen(source, timeout=timeout, phrase_time_limit=phrase_time_limit)
+        try:
+            text = recognizer.recognize_google(audio)
+            print(f"[STT] Transcribed: {text}")
+            return text
+        except sr.RequestError:
+            print("[STT] API unavailable, trying offline recognition")
+            try:
+                text = recognizer.recognize_sphinx(audio)
+                print(f"[STT] Transcribed (Sphinx): {text}")
+                return text
+            except Exception as e:
+                print(f"[STT] Offline recognition failed: {e}")
+        except sr.UnknownValueError:
+            print("[STT] Unable to recognize speech")
+    except Exception as e:
+        print(f"[STT] Error while capturing audio: {e}")
+    return ""

--- a/tts_engine.py
+++ b/tts_engine.py
@@ -1,7 +1,9 @@
 import pyttsx3
 
 # Simple offline TTS using pyttsx3 for now
+
 def generate_tts(text, output_path):
+    """Synthesize ``text`` to ``output_path`` as a WAV file."""
     try:
         print(f"[TTS] Synthesizing audio for: '{text}' → {output_path}")
         engine = pyttsx3.init()
@@ -10,3 +12,14 @@ def generate_tts(text, output_path):
         engine.runAndWait()
     except Exception as e:
         print(f"[TTS] Error generating speech for '{text}': {e}")
+
+
+def speak(text):
+    """Speak ``text`` directly through the speakers (no file output)."""
+    try:
+        engine = pyttsx3.init()
+        engine.setProperty('rate', 160)
+        engine.say(text)
+        engine.runAndWait()
+    except Exception as e:
+        print(f"[TTS] Error speaking '{text}': {e}")


### PR DESCRIPTION
## Summary
- handle up to 50 adjacency responses when building a new glyph
- track adjacency weights in `SKGEngine`
- add new `stt_engine` module for microphone speech recognition
- enhance `tts_engine` with `speak()` helper for immediate playback
- update main loop to support speech input and speak results

## Testing
- `python -m py_compile stt_engine.py tts_engine.py glyph_builder.py skg_engine.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_6841ff3c0418832d99ba28faefc694a0