### PR TITLE
Update font path to absolute project root

### DIFF
--- a/_SCRAP-YARD/glyph_renderer.py
+++ b/_SCRAP-YARD/glyph_renderer.py
@@ -13,7 +13,9 @@ os.makedirs(GLYPH_IMAGE_DIR, exist_ok=True)
 # Ensure the Symbola font exists at the specified path
 try:
     if not os.path.exists(FONT_PATH):
-        raise FileNotFoundError(f"[ERROR] Missing font: {FONT_PATH}. Please ensure Symbola.ttf is located in the '_fonts' directory.")
+        raise FileNotFoundError(
+            f"[ERROR] Missing font: {FONT_PATH}. Please ensure Symbola.ttf is located in the repository root."
+        )
 except FileNotFoundError as e:
     print(e)
     exit(1)

--- a/_SCRAP-YARD/symbolic_constants.py
+++ b/_SCRAP-YARD/symbolic_constants.py
@@ -157,7 +157,11 @@ PROTO_SIGIL_TOKENS = [
 
 
 # Base font path for glyph rendering
-DEFAULT_GLYPH_FONT_PATH = "_fonts/Symbola.ttf"
+# Resolve the path to Symbola.ttf relative to the repository root so
+# it works regardless of the current working directory
+import os
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DEFAULT_GLYPH_FONT_PATH = os.path.join(_REPO_ROOT, "Symbola.ttf")
 
 # Image sizes for glyph and FFT rendering
 GLYPH_IMAGE_SIZE = (512, 512)

--- a/glyph_visualizer.py
+++ b/glyph_visualizer.py
@@ -4,7 +4,12 @@ from PIL import Image, ImageDraw, ImageFont
 import hashlib
 from datetime import datetime
 
-def generate_glyph_image(token, output_dir="modalities/images", font_path="../Symbola.ttf"):
+def generate_glyph_image(
+    token,
+    output_dir="modalities/images",
+    # Resolve the font path relative to the repository root
+    font_path=os.path.join(os.path.dirname(os.path.abspath(__file__)), "Symbola.ttf"),
+):
     """
     Generate and save an image of a glyph corresponding to the given token.
     """


### PR DESCRIPTION
## Summary
- resolve `Symbola.ttf` location relative to repo root in `symbolic_constants`
- update `glyph_visualizer` default font path to use the absolute location

## Testing
- `python -m py_compile _SCRAP-YARD/symbolic_constants.py _SCRAP-YARD/glyph_renderer.py glyph_visualizer.py`


------
https://chatgpt.com/codex/tasks/task_e_684205dccad8832d80ddbf8f5b745ed2