### PR TITLE
Fix glyph usage example

### DIFF
--- a/glyph_visualizer.py
+++ b/glyph_visualizer.py
@@ -67,4 +67,6 @@ token_data = {
 }
 
 # This would typically be triggered from agency gate decisions in the recursive process
-externalize_token(token_data["token"], token_data)
+
+if __name__ == "__main__":
+    externalize_token(token_data["token"], token_data)


### PR DESCRIPTION
## Summary
- move glyph_visualizer example usage into a main guard

## Testing
- `python -m py_compile glyph_visualizer.py`

------
https://chatgpt.com/codex/tasks/task_e_684215fe6064832da65ccc2775e5a2a2