### PR TITLE
Fix font path handling

### DIFF
--- a/glyph_visualizer.py
+++ b/glyph_visualizer.py
@@ -4,7 +4,10 @@ from PIL import Image, ImageDraw, ImageFont
 import hashlib
 from datetime import datetime
 
-def generate_glyph_image(token, output_dir="modalities/images", font_path="../Symbola.ttf"):
+FONT_PATH = os.path.join(os.path.dirname(__file__), "Symbola.ttf")
+
+
+def generate_glyph_image(token, output_dir="modalities/images", font_path=FONT_PATH):
     """
     Generate and save an image of a glyph corresponding to the given token.
     """


### PR DESCRIPTION
## Summary
- ensure `glyph_visualizer` computes the `Symbola.ttf` path relative to the file so the font loads correctly

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684215ff6ba8832dbdede80aa948ad23