### PR TITLE
Improve SKGEngine logging and console view

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# FFT-SKG-AGI
+
+This project explores a minimal symbolic cognition loop. The `SKGEngine` maps tokens to glyphs and recursively walks their adjacencies. When a token is externalized the console is cleared and a compressed view of the last thought loop is displayed.
+
+## Usage
+
+Run the main script and enter tokens at the prompt:
+
+```bash
+python main.py
+```
+
+Externalization events are indicated with a clear screen followed by the most recent tokens processed.
+
+During these events `main.py` clears the terminal with `cls` or `clear` and prints a concise list of the latest thought loop tokens.
+
+### Engine messages
+
+`assign_glyph_to_token` now prints whether a glyph was reused or newly assigned and shows the current weight. `externalize_token` reports the glyph and weight being externalized.

--- a/main.py
+++ b/main.py
@@ -1,9 +1,7 @@
 import os
 import json
-from glyph_visualizer import generate_glyph_image
 from skg_engine import SKGEngine
 from glyph_builder import build_glyph_if_needed
-from agency_gate import process_agency_gates
 
 required_dirs = [
     "modalities/fft_visual",
@@ -23,6 +21,13 @@ os.makedirs(data_path, exist_ok=True)
 # Initialize engine
 skg = SKGEngine(data_path)
 
+# Load the extended glyph pool so the engine has options
+glyph_pool_path = "extended_glyph_pool.json"
+if os.path.exists(glyph_pool_path):
+    with open(glyph_pool_path, "r", encoding="utf-8") as f:
+        for g in json.load(f):
+            skg.add_glyph_to_pool(g)
+
 
 def load_or_create_glyph(token):
     glyph_path = os.path.join(data_path, f"{token}.json")
@@ -41,24 +46,20 @@ def save_glyph(glyph):
 
 
 def process_input(user_input):
-    # Assuming you're processing the 'user_input' to get the glyph and its data
-    token = user_input.lower()  # Get token from user input
-    
-    # Create token data based on the token (example with frequency and weight)
-    token_data = {
-        "token": token,
-        "frequency": 1,  # You can adjust based on context or token history
-        "weight": 1      # You can adjust based on your logic (e.g., weight might increase with each occurrence)
-    }
+    token = user_input.lower()
 
-    # Simulate generating the glyph for the token (you may already have this elsewhere)
-    glyph = generate_glyph_image(token)  # Assuming this returns a glyph image or associated glyph info
+    glyph_data = load_or_create_glyph(token)
+    if glyph_data.get("glyph_id") not in skg.glyph_pool:
+        skg.add_glyph_to_pool(glyph_data.get("glyph_id"))
 
-    # Now you call the process_agency_gates with the token_data
-    decisions = process_agency_gates(token, token_data)
+    skg.recursive_thought_loop(token)
+    save_glyph(glyph_data)
 
-    # Handle decisions (e.g., proceed with externalization, exploration, etc.)
-    print(decisions)
+    if skg.externalized_last:
+        os.system("cls" if os.name == "nt" else "clear")
+        print("[Main] Recent thought loop:")
+        print(" -> ".join(skg.thought_history[-10:]))
+        skg.externalized_last = False
 
 
 


### PR DESCRIPTION
## Summary
- add startup glyph pool load and thought loop display
- record and show glyph assignment details
- clear console when externalizing tokens
- document console behaviour in README

## Testing
- `python -m py_compile main.py skg_engine.py`
- `python -m py_compile agency_gate.py glyph_visualizer.py glyph_builder.py modalities.py tts_engine.py adjacency_seed.py fft_generator.py generate_fft_from_image.py image_search.py`


------
https://chatgpt.com/codex/tasks/task_e_684216034b14832d9c19bf396ce0e09e