### PR TITLE
Wrap example usage in __main__ guard

### DIFF
--- a/glyph_visualizer.py
+++ b/glyph_visualizer.py
@@ -59,12 +59,13 @@ def externalize_token(token, token_data, output_dir="modalities/images"):
     else:
         print(f"Failed to externalize token: {token}")
 
-# Example usage:
-token_data = {
-    "token": "truth",  # Token name
-    "frequency": 5,    # Frequency (useful for gate decisions)
-    "weight": 10       # Weight (for decision making)
-}
+if __name__ == "__main__":
+    # Example usage:
+    token_data = {
+        "token": "truth",  # Token name
+        "frequency": 5,    # Frequency (useful for gate decisions)
+        "weight": 10       # Weight (for decision making)
+    }
 
-# This would typically be triggered from agency gate decisions in the recursive process
-externalize_token(token_data["token"], token_data)
+    # This would typically be triggered from agency gate decisions in the recursive process
+    externalize_token(token_data["token"], token_data)


### PR DESCRIPTION
## Summary
- prevent glyph_visualizer from running externalize_token on import

## Testing
- `python -m py_compile glyph_visualizer.py`
- *(failed: `python - <<'PY' ...` due to missing `PIL`)*

------
https://chatgpt.com/codex/tasks/task_e_6840afb2a61c832db7f631616306d71e