### PR TITLE
Fix Symbola font lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,26 +69,28 @@ This renders relationships between tokens, agency gates, and decisions based on 
 🖋️ Using Symbola for Unicode Glyphs
 Some features rely on the Symbola font to properly render advanced Unicode glyphs (e.g. 🜂, ⚚, 🜁).
 
-🔽 Download Instructions
-Download Symbola.ttf from a trusted source like Font Library.
+### Download Instructions
+Download `Symbola.ttf` from a trusted source like Font Library and place it in a known directory:
 
-Place it in a known directory, e.g.:
-
-bash
-Copy
-Edit
+```bash
 mkdir _fonts
 mv /path/to/Symbola.ttf _fonts/
-🧱 Usage Example
-To generate a glyph image using the font:
+```
 
-python
-Copy
-Edit
+Set the `SYMBOLA_FONT_PATH` environment variable to the location of your font if
+it is not in the project root. The engine will also check the `_fonts/`
+directory automatically.
+
+### Usage Example
+To generate a glyph image using the font directly:
+
+```python
 from glyph_visualizer import generate_glyph_image
 
 image_path = generate_glyph_image("🜂", font_path="_fonts/Symbola.ttf")
-If no font_path is given and the default path fails, it falls back to a generic system font via Pillow.
+```
+If no `font_path` is given and the default path fails, it falls back to a
+generic system font via Pillow.
 
 🔧 Requirements
 Install dependencies with:

--- a/glyph_visualizer.py
+++ b/glyph_visualizer.py
@@ -14,11 +14,24 @@ if getattr(sys.modules.get("__main__"), "__file__", None):
 else:
     MAIN_DIR = os.path.dirname(os.path.abspath(__file__))
 
-# Try loading Symbola from alongside main.py, falling back to this file's
-# location.
-DEFAULT_FONT_PATH = os.path.join(MAIN_DIR, "Symbola.ttf")
-if not os.path.exists(DEFAULT_FONT_PATH):
-    DEFAULT_FONT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Symbola.ttf")
+# Resolve the path to Symbola.ttf.
+# 1. `SYMBOLA_FONT_PATH` environment variable has highest priority.
+# 2. Symbola.ttf in the directory containing main.py.
+# 3. Symbola.ttf in a `_fonts/` folder next to main.py.
+# 4. Symbola.ttf next to this file.
+env_font = os.environ.get("SYMBOLA_FONT_PATH")
+if env_font and os.path.exists(env_font):
+    DEFAULT_FONT_PATH = env_font
+else:
+    DEFAULT_FONT_PATH = os.path.join(MAIN_DIR, "Symbola.ttf")
+    if not os.path.exists(DEFAULT_FONT_PATH):
+        alt_path = os.path.join(MAIN_DIR, "_fonts", "Symbola.ttf")
+        if os.path.exists(alt_path):
+            DEFAULT_FONT_PATH = alt_path
+        else:
+            alt_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "Symbola.ttf")
+            if os.path.exists(alt_path):
+                DEFAULT_FONT_PATH = alt_path
 
 def generate_glyph_image(token, output_dir="modalities/images", font_path=None):
     """


### PR DESCRIPTION
## Summary
- document how to set `SYMBOLA_FONT_PATH`
- support finding Symbola.ttf via environment variable and `_fonts/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68427506c63c832d9c9069a0b61fe8b4