### PR TITLE
Fix font fallback and FFT resizing

### DIFF
--- a/adjacency_seed.py
+++ b/adjacency_seed.py
@@ -81,7 +81,7 @@ def generate_adjacents(token: str, top_k: int = 5) -> list[dict]:
             for line in lines:
                 parts = line.split(":", 1)
                 if len(parts) == 2:
-                    candidates.append(parts[1].strip())
+                    candidates.append(parts[1].strip().strip(' ",'))
             return _format_adjacents(candidates[:top_k])
         except Exception as e:
             print(f"[AdjacencySeed] Error generating adjacents for '{token}': {e}")

--- a/generate_fft_from_image.py
+++ b/generate_fft_from_image.py
@@ -16,7 +16,10 @@ def generate_fft_from_image(image_path: str, output_dir: str = "modalities/fft_v
         return None
     try:
         img = Image.open(image_path).convert("L")
-        img = img.resize((max_dim, max_dim), Image.ANTIALIAS)
+        width, height = img.size
+        scale = min(max_dim / width, max_dim / height)
+        new_width, new_height = int(width * scale), int(height * scale)
+        img = img.resize((new_width, new_height), Image.Resampling.LANCZOS)
         arr = np.array(img)
         fft = np.fft.fftshift(np.fft.fft2(arr))
         magnitude = np.abs(fft)

--- a/glyph_visualizer.py
+++ b/glyph_visualizer.py
@@ -48,9 +48,13 @@ def generate_glyph_image(token: str, output_dir: str = "modalities/images", font
     try:
         try:
             font = ImageFont.truetype(font_path, font_size)
-        except Exception as e:
-            print(f"[GlyphVisualizer] Warning: Could not load Symbola font: {e}")
-            font = ImageFont.load_default()
+        except Exception:
+            fallback = os.path.join("fonts", "Symbola.ttf")
+            try:
+                font = ImageFont.truetype(fallback, font_size)
+            except Exception:
+                print("[GlyphVisualizer] Warning: Could not load Symbola font — using default")
+                font = ImageFont.load_default()
         img = Image.new("RGB", (width, height), color=background_color)
         draw = ImageDraw.Draw(img)
         bbox = draw.textbbox((0, 0), token, font=font)

--- a/offline_adjacency.json
+++ b/offline_adjacency.json
@@ -1,5 +1,6 @@
 {
     "test": ["example", "experiment", "trial", "analysis", "check"],
     "hello": ["hi", "greetings", "hey", "salutation", "welcome"],
-    "world": ["earth", "globe", "planet", "sphere", "universe"]
+    "world": ["earth", "globe", "planet", "sphere", "universe"],
+    "fire": ["flame", "heat", "burn", "ember", "smoke"]
 }


### PR DESCRIPTION
## Summary
- improve fallback parsing in `adjacency_seed`
- resize FFT images with LANCZOS scaling
- add fallback font search path in `glyph_visualizer`
- add missing offline entry for tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ba964f85c832d8aee0ef69140a8c2