### PR TITLE
Add mic audio saving and FFT to STT

### DIFF
--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ def main() -> None:
         if user_input.lower() == 'exit':
             break
         elif user_input.lower() == 'voice':
-            spoken = transcribe_speech()
+            spoken, audio_path = transcribe_speech()
             if spoken:
                 speak(f"You said {spoken}")
                 process_input(spoken, skg)

--- a/offline_adjacency.json
+++ b/offline_adjacency.json
@@ -1,5 +1,6 @@
 {
     "test": ["example", "experiment", "trial", "analysis", "check"],
     "hello": ["hi", "greetings", "hey", "salutation", "welcome"],
-    "world": ["earth", "globe", "planet", "sphere", "universe"]
+    "world": ["earth", "globe", "planet", "sphere", "universe"],
+    "fire": ["flame", "heat", "burn", "ember", "ignite"]
 }

--- a/stt_engine.py
+++ b/stt_engine.py
@@ -1,37 +1,74 @@
+import os
+from datetime import datetime
+
 try:
     import speech_recognition as sr  # type: ignore
 except Exception:
     sr = None  # type: ignore
 
+try:
+    from fft_generator import generate_fft_from_audio
+except Exception:
+    generate_fft_from_audio = None  # type: ignore
 
-def transcribe_speech(timeout: int = 5, phrase_time_limit: int = 5) -> str:
+
+def transcribe_speech(timeout: int = 5, phrase_time_limit: int = 5) -> tuple[str, str | None]:
     """
-    Capture audio from the default microphone and return recognized text.
-    If speech recognition is not available an empty string is returned and
-    a warning printed.
+    Capture audio from the microphone, save it to ``modalities/audio_input`` and
+    return a tuple ``(transcript, audio_path)``.  ``audio_path`` may be ``None``
+    if recording fails.  If speech recognition is unavailable the transcript is
+    an empty string and only the raw audio (if any) is returned.
     """
     if sr is None:
         print("[STT] speech_recognition not installed; skipping transcription")
-        return ""
+        return "", None
+
     recognizer = sr.Recognizer()
+    audio_path: str | None = None
+
     try:
         with sr.Microphone() as source:
             print("[STT] Listening...")
             audio = recognizer.listen(source, timeout=timeout, phrase_time_limit=phrase_time_limit)
+
+        # Save the captured audio before attempting transcription
+        try:
+            os.makedirs("modalities/audio_input", exist_ok=True)
+            timestamp = datetime.utcnow().strftime("%Y%m%d_%H%M%S")
+            audio_path = os.path.join("modalities/audio_input", f"mic_{timestamp}.wav")
+            with open(audio_path, "wb") as f:
+                f.write(audio.get_wav_data())
+        except Exception as e:
+            print(f"[STT] Failed to save microphone audio: {e}")
+
+        # Generate FFT data and image for the captured file
+        if audio_path and generate_fft_from_audio:
+            try:
+                os.makedirs("modalities/fft_audio", exist_ok=True)
+                os.makedirs("modalities/fft_visual", exist_ok=True)
+                base = os.path.splitext(os.path.basename(audio_path))[0]
+                fft_data_path = os.path.join("modalities/fft_audio", f"{base}.npy")
+                fft_image_path = os.path.join("modalities/fft_visual", f"{base}.png")
+                generate_fft_from_audio(audio_path, fft_data_path, fft_image_path)
+            except Exception as e:
+                print(f"[STT] Error generating FFT: {e}")
+
+        # Perform transcription
         try:
             text = recognizer.recognize_google(audio)
             print(f"[STT] Transcribed: {text}")
-            return text
+            return text, audio_path
         except sr.RequestError:
             print("[STT] API unavailable, trying offline recognition")
             try:
                 text = recognizer.recognize_sphinx(audio)
                 print(f"[STT] Transcribed (Sphinx): {text}")
-                return text
+                return text, audio_path
             except Exception as e:
                 print(f"[STT] Offline recognition failed: {e}")
         except sr.UnknownValueError:
             print("[STT] Unable to recognize speech")
     except Exception as e:
         print(f"[STT] Error while capturing audio: {e}")
-    return ""
+
+    return "", audio_path


### PR DESCRIPTION
## Summary
- extend STT to write microphone recordings to `modalities/audio_input`
- generate FFT data and image for captured audio
- return waveform path along with transcript
- adjust `main.py` to handle new return value
- expand offline adjacency data for tests

## Testing
- `python -m unittest discover -s tests -v`


------
https://chatgpt.com/codex/tasks/task_e_688bc0563208832daa2674252624ffbe