### PR TITLE
Add inter-engine communication and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ python main.py
 
 Interactively enter tokens or use `voice` input. Modalities are generated, logged, and visualized (if enabled). Type `exit` to quit.
 
+### Engine-to-Engine Communication
+
+`config.py` contains options to broadcast externalized tokens to a file based stream and to subscribe to another engine's stream. When `ENABLE_ENGINE_COMM` is set to `True`, each externalized token is appended as a JSON line to `engine_stream.jsonl` in the engine's memory directory. Setting `SUBSCRIBE_STREAM` to the path of another engine's stream file will feed received tokens back into the local `recursive_thought_loop`.
+
+This mechanism allows multiple engines to share glyph streams without requiring a network stack and can be toggled in the forthcoming GUI.
+
 ### Rendering Graphs
 
 ```bash

--- a/config.py
+++ b/config.py
@@ -1,0 +1,7 @@
+"""Global configuration options for the SKG engine and forthcoming GUI."""
+
+# Enable or disable engine-to-engine communication
+ENABLE_ENGINE_COMM = False
+
+# Path to subscribe to another engine's stream. Leave None to disable
+SUBSCRIBE_STREAM = None

--- a/engine_comm.py
+++ b/engine_comm.py
@@ -1,0 +1,37 @@
+import os
+import json
+import threading
+import time
+from typing import Optional
+
+
+def write_message(stream_path: str, token: str, glyph: str) -> None:
+    """Append a token/glyph pair to the stream file as a JSON line."""
+    os.makedirs(os.path.dirname(stream_path), exist_ok=True)
+    with open(stream_path, "a", encoding="utf-8") as f:
+        f.write(json.dumps({"token": token, "glyph": glyph}) + "\n")
+
+
+def subscribe_to_stream(stream_path: str, callback, poll_interval: float = 1.0) -> threading.Thread:
+    """Watch a stream file and invoke callback(token) for each new entry."""
+    def monitor() -> None:
+        # Wait for file to exist
+        while not os.path.exists(stream_path):
+            time.sleep(poll_interval)
+        with open(stream_path, "r", encoding="utf-8") as f:
+            f.seek(0, os.SEEK_END)
+            while True:
+                line = f.readline()
+                if not line:
+                    time.sleep(poll_interval)
+                    continue
+                try:
+                    data = json.loads(line.strip())
+                    token = data.get("token")
+                    if token:
+                        callback(token)
+                except json.JSONDecodeError:
+                    continue
+    t = threading.Thread(target=monitor, daemon=True)
+    t.start()
+    return t

--- a/main.py
+++ b/main.py
@@ -1,6 +1,7 @@
 import os
 import json
 from skg_engine import SKGEngine
+import config
 from glyph_builder import build_glyph_if_needed
 from agency_gate import process_agency_gates  # noqa: F401  # imported for side effects
 from tts_engine import speak
@@ -75,8 +76,10 @@ def process_input(user_input: str, skg: SKGEngine) -> None:
 
 
 def main() -> None:
-    # Initialize symbolic cognition engine
-    skg = SKGEngine(data_path)
+    # Initialize symbolic cognition engine with communication options
+    skg = SKGEngine(data_path, comm_enabled=config.ENABLE_ENGINE_COMM)
+    if config.ENABLE_ENGINE_COMM and config.SUBSCRIBE_STREAM:
+        skg.subscribe_to_engine(config.SUBSCRIBE_STREAM)
     # Load extended glyph pool if available
     glyph_pool_path = "glossary/extended_glyph_pool.json"
     if os.path.exists(glyph_pool_path):

--- a/offline_adjacency.json
+++ b/offline_adjacency.json
@@ -1,5 +1,6 @@
 {
     "test": ["example", "experiment", "trial", "analysis", "check"],
     "hello": ["hi", "greetings", "hey", "salutation", "welcome"],
-    "world": ["earth", "globe", "planet", "sphere", "universe"]
+    "world": ["earth", "globe", "planet", "sphere", "universe"],
+    "fire": ["flame", "heat", "burn", "ignite", "smoke"]
 }


### PR DESCRIPTION
## Summary
- add simple file-based protocol for engines to broadcast externalized tokens
- allow an engine to subscribe to another's output
- configure communication settings in new `config.py`
- document feature in README
- extend offline adjacency data for tests

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_688bc0a4a7c8832d9a6b918c9af625f4