### PR TITLE
Add TokenFusion to unify token IDs

### DIFF
--- a/glyph_builder.py
+++ b/glyph_builder.py
@@ -4,9 +4,12 @@ from datetime import datetime
 from adjacency_seed import generate_adjacents
 from modalities import generate_modalities
 from glyph_decision_engine import choose_glyph_for_token
+from token_fusion import TokenFusion
+
+fusion = TokenFusion()
 
 
-def build_glyph_if_needed(token: str, path: str, adj_count: int = 50) -> dict:
+def build_glyph_if_needed(token: str, base_dir: str, adj_count: int = 50) -> dict:
     """
     Create a glyph representation for a token if it does not already exist.
 
@@ -23,8 +26,8 @@ def build_glyph_if_needed(token: str, path: str, adj_count: int = 50) -> dict:
     ----------
     token : str
         The token for which a glyph is being created.
-    path : str
-        The file path under which to persist the resulting glyph JSON.
+    base_dir : str
+        Directory where glyph JSON files are stored.
     adj_count : int
         Number of adjacents to request when generating adjacency context.
 
@@ -35,6 +38,8 @@ def build_glyph_if_needed(token: str, path: str, adj_count: int = 50) -> dict:
     """
     print(f"[GlyphBuilder] Building glyph for unknown token: '{token}'")
     now = datetime.utcnow().isoformat() + "Z"
+    token_id = fusion.fuse_token(token)
+    path = os.path.join(base_dir, f"{token_id}.json")
 
     # Step 1: Generate adjacents first (required for glyph decision)
     try:
@@ -52,7 +57,7 @@ def build_glyph_if_needed(token: str, path: str, adj_count: int = 50) -> dict:
 
     # Step 3: Generate modalities (FFT, TTS, image, etc.)
     try:
-        modalities = generate_modalities(token, glyph_id)
+        modalities = generate_modalities(token, glyph_id, token_id)
     except Exception as e:
         print(f"[GlyphBuilder] Error generating modalities for '{token}': {e}")
         # Provide a minimal modalities structure

--- a/main.py
+++ b/main.py
@@ -3,6 +3,9 @@ import json
 from skg_engine import SKGEngine
 import config
 from glyph_builder import build_glyph_if_needed
+from token_fusion import TokenFusion
+
+fusion = TokenFusion()
 from agency_gate import process_agency_gates  # noqa: F401  # imported for side effects
 from tts_engine import speak
 from stt_engine import transcribe_speech
@@ -26,17 +29,19 @@ os.makedirs(data_path, exist_ok=True)
 
 
 def load_or_create_glyph(token: str) -> dict:
-    glyph_path = os.path.join(data_path, f"{token}.json")
+    token_id = fusion.fuse_token(token)
+    glyph_path = os.path.join(data_path, f"{token_id}.json")
     if os.path.exists(glyph_path):
         with open(glyph_path, 'r', encoding='utf-8') as f:
             return json.load(f)
     else:
-        glyph = build_glyph_if_needed(token, glyph_path, adj_count=50)
+        glyph = build_glyph_if_needed(token, data_path, adj_count=50)
         return glyph
 
 
 def save_glyph(glyph: dict) -> None:
-    glyph_path = os.path.join(data_path, f"{glyph['token']}.json")
+    token_id = fusion.fuse_token(glyph['token'])
+    glyph_path = os.path.join(data_path, f"{token_id}.json")
     try:
         with open(glyph_path, 'w', encoding='utf-8') as f:
             json.dump(glyph, f, indent=2)

--- a/modalities.py
+++ b/modalities.py
@@ -1,6 +1,5 @@
 import os
 import json
-import hashlib
 from typing import List
 
 # Import optional dependencies within try/except so that missing libraries
@@ -27,7 +26,7 @@ except Exception:
     generate_glyph_image = None  # type: ignore
 
 
-def generate_modalities(token: str, glyph_id: str) -> dict:
+def generate_modalities(token: str, glyph_id: str, token_id: str) -> dict:
     """
     Generate and store multimodal representations for a token/glyph.
 
@@ -39,13 +38,12 @@ def generate_modalities(token: str, glyph_id: str) -> dict:
     cannot be produced its entry will either be omitted or set to None.
     """
     print(f"[Modalities] Generating modalities for: {token} / {glyph_id}")
-    hash_id = hashlib.sha1(token.encode()).hexdigest()[:8]
 
-    # Construct file paths
-    audio_path = f"modalities/audio/{token}_{hash_id}.wav"
-    fft_audio_path = f"modalities/fft_audio/{token}_{hash_id}.npy"
-    fft_visual_path = f"modalities/fft_visual/{token}_{hash_id}.png"
-    symbolic_image_path = f"modalities/images/{token}_{hash_id}_sigil.png"
+    # Construct file paths using the shared token_id
+    audio_path = f"modalities/audio/{token_id}.wav"
+    fft_audio_path = f"modalities/fft_audio/{token_id}.npy"
+    fft_visual_path = f"modalities/fft_visual/{token_id}.png"
+    symbolic_image_path = f"modalities/images/{token_id}_sigil.png"
 
     # Ensure directories exist
     for p in [audio_path, fft_audio_path, fft_visual_path, symbolic_image_path]:

--- a/tests/test_token_fusion.py
+++ b/tests/test_token_fusion.py
@@ -1,0 +1,29 @@
+import os
+import json
+import tempfile
+import unittest
+from token_fusion import TokenFusion
+from glyph_builder import build_glyph_if_needed
+
+
+class TestTokenFusion(unittest.TestCase):
+    def test_text_and_stt_share_glyph(self):
+        fusion = TokenFusion()
+        phrase = "hello world"
+        tid_text = fusion.fuse_token(phrase)
+        tid_speech = fusion.fuse_from_stt(phrase)
+        self.assertEqual(tid_text, tid_speech)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            glyph1 = build_glyph_if_needed(phrase, tmp, adj_count=1)
+            glyph2 = build_glyph_if_needed(phrase, tmp, adj_count=1)
+            path = os.path.join(tmp, f"{tid_text}.json")
+            self.assertTrue(os.path.exists(path))
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            self.assertEqual(data["token"], phrase)
+            self.assertEqual(glyph1["glyph_id"], glyph2["glyph_id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/token_fusion.py
+++ b/token_fusion.py
@@ -1,0 +1,23 @@
+import hashlib
+from typing import Dict
+
+class TokenFusion:
+    """Map tokens from different modalities to a shared deterministic ID."""
+
+    def __init__(self) -> None:
+        self.token_map: Dict[str, str] = {}
+
+    def _canonical(self, token: str) -> str:
+        return token.strip().lower()
+
+    def fuse_token(self, token: str) -> str:
+        canon = self._canonical(token)
+        token_id = hashlib.sha1(canon.encode()).hexdigest()[:8]
+        self.token_map[canon] = token_id
+        return token_id
+
+    def fuse_from_stt(self, transcript: str) -> str:
+        return self.fuse_token(transcript)
+
+    def fuse_from_image(self, label: str) -> str:
+        return self.fuse_token(label)


### PR DESCRIPTION
## Summary
- introduce `TokenFusion` for deterministic token IDs
- update glyph building and modality generation to use shared IDs
- adapt main loader/saver to use new hashed ID paths
- test that speech and text share the same glyph

## Testing
- `pytest -q` *(fails: IndentationError in skg_engine.py and SyntaxError in adjacency_seed.py)*

------
https://chatgpt.com/codex/tasks/task_e_688bc553f998832d87862605311da6f4