### PR TITLE
Add expression modality gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `SKGEngine` orchestrates:
 * Recursive token processing
 * Glyph-symbolic memory mapping
 * Modalities generation (voice, vision, frequency)
-* Agency gating (decisions on whether to speak, silence, or recurse)
+* Agency gating (decisions on whether to speak, gesture, silence, or recurse)
 
 This architecture is the core cognition engine behind real-time symbolic digital twins.
 
@@ -58,6 +58,17 @@ The system can be extended into a full real-time avatar with:
 
 * `glyph_memory/` stores token histories, glyph assignments, and agency gate traces
 * Logs are replayable for full thought loop reconstruction
+
+The agency gate also selects an **expression modality**. Tokens with higher
+confidence are spoken aloud, while low-confidence tokens trigger a gesture cue.
+For example:
+
+```python
+gate, modality, conf = engine.evaluate_agency_gate("hello")
+# ("externalize", "speak", 0.7)
+```
+A confidence below 0.5 yields `("gesture")`, which the GUI displays as a simple
+icon instead of speech.
 
 ---
 

--- a/adjacency_seed.py
+++ b/adjacency_seed.py
@@ -100,6 +100,7 @@ def generate_adjacents(token: str, top_k: int = 5) -> list[dict]:
     return _format_adjacents(variations[:top_k], source="fallback")
 
 
+
 def _format_adjacents(adj_list: list[str], source: str = "GPT") -> list[dict]:
     return [
         {
@@ -109,4 +110,4 @@ def _format_adjacents(adj_list: list[str], source: str = "GPT") -> list[dict]:
             "source": source,
         }
         for adj in adj_list if isinstance(adj, str)
-    
+    ]

--- a/agency_gate.py
+++ b/agency_gate.py
@@ -18,7 +18,7 @@ def process_agency_gates(token: str, token_data: dict, adjacency_count: int = 0)
         Number of adjacent tokens currently associated with this token.
     """
     print(f"[AgencyGate] Processing gates for token: {token}")
-    gates = ["explore", "reevaluate", "externalize", "prune"]
+    gates = ["explore", "reevaluate", "externalize", "prune", "expression"]
     decisions: list[dict] = []
     frequency = token_data.get("frequency", 1)
     weight = token_data.get("weight", 1)
@@ -53,6 +53,21 @@ def process_agency_gates(token: str, token_data: dict, adjacency_count: int = 0)
             decisions.append({
                 "gate": gate,
                 "decision": prune_decision,
+                "timestamp": datetime.utcnow().isoformat() + "Z"
+            })
+        elif gate == "expression":
+            speak_conf = min(1.0, 0.3 + (weight * 0.1))
+            gesture_conf = 1.0 - speak_conf
+            if speak_conf >= gesture_conf:
+                decision = "speak"
+                confidence = speak_conf
+            else:
+                decision = "gesture"
+                confidence = gesture_conf
+            decisions.append({
+                "gate": gate,
+                "decision": decision,
+                "confidence": round(confidence, 2),
                 "timestamp": datetime.utcnow().isoformat() + "Z"
             })
     return decisions

--- a/avatar_gui.py
+++ b/avatar_gui.py
@@ -1,86 +1,87 @@
-diff --git a//dev/null b/avatar_gui.py
-index 0000000000000000000000000000000000000000..c7e402f7724deee23c4bf91fc5dd6248b4ce181c 100644
---- a//dev/null
-+++ b/avatar_gui.py
-@@ -0,0 +1,81 @@
-+import os
-+import math
-+import queue
-+import tkinter as tk
-+from typing import Optional
-+
-+
-+class AvatarGUI:
-+    """Minimal Tkinter interface showing glyphs, FFT images and adjacency graph."""
-+
-+    def __init__(self, engine) -> None:
-+        self.engine = engine
-+        self.root = tk.Tk()
-+        self.root.title("Avatar GUI")
-+        self.update_queue: queue.Queue = queue.Queue()
-+        self.images: dict[str, tk.PhotoImage] = {}
-+        # glyph display
-+        self.glyph_label = tk.Label(self.root, text="Glyph", width=256, height=256)
-+        self.glyph_label.grid(row=0, column=0, padx=5, pady=5)
-+        # adjacency canvas
-+        self.graph_canvas = tk.Canvas(self.root, width=256, height=256, bg="white")
-+        self.graph_canvas.grid(row=0, column=1, padx=5, pady=5)
-+        # audio/image FFT
-+        self.audio_fft_label = tk.Label(self.root, text="Audio FFT", width=256, height=256)
-+        self.audio_fft_label.grid(row=1, column=0, padx=5, pady=5)
-+        self.image_fft_label = tk.Label(self.root, text="Image FFT", width=256, height=256)
-+        self.image_fft_label.grid(row=1, column=1, padx=5, pady=5)
-+        self.last_token: Optional[str] = None
-+
-+    def run(self) -> None:
-+        self.root.after(200, self.process_queue)
-+        self.root.mainloop()
-+
-+    def process_queue(self) -> None:
-+        while not self.update_queue.empty():
-+            glyph = self.update_queue.get()
-+            self._update_display(glyph)
-+        self.root.after(200, self.process_queue)
-+
-+    def update_from_token(self, glyph: dict) -> None:
-+        self.update_queue.put(glyph)
-+
-+    def _set_image(self, label: tk.Label, path: Optional[str], key: str) -> None:
-+        if path and os.path.exists(path):
-+            try:
-+                photo = tk.PhotoImage(file=path)
-+                label.configure(image=photo, text="")
-+                self.images[key] = photo
-+            except Exception:
-+                label.configure(text="(image error)", image="")
-+        else:
-+            label.configure(text="No image", image="")
-+
-+    def _update_display(self, glyph: dict) -> None:
-+        self.last_token = glyph.get("token")
-+        visual = glyph.get("modalities", {}).get("visual", {})
-+        audio_mod = glyph.get("modalities", {}).get("audio", {})
-+        self._set_image(self.glyph_label, visual.get("symbolic_image"), "glyph")
-+        self._set_image(self.audio_fft_label, audio_mod.get("fft_audio"), "audio")
-+        img_fft = visual.get("fft_from_image") or visual.get("fft_visual")
-+        self._set_image(self.image_fft_label, img_fft, "imgfft")
-+        self._update_graph()
-+
-+    def _update_graph(self) -> None:
-+        self.graph_canvas.delete("all")
-+        token = self.last_token
-+        if not token:
-+            return
-+        center_x = center_y = 128
-+        radius = 90
-+        self.graph_canvas.create_oval(center_x-20, center_y-20, center_x+20, center_y+20, fill="lightblue")
-+        self.graph_canvas.create_text(center_x, center_y, text=token)
-+        adjs = list(self.engine.get_adjacencies_for_token(token).keys())[:6]
-+        for i, adj in enumerate(adjs):
-+            angle = math.radians(i * (360/len(adjs))) if adjs else 0
-+            x = center_x + radius * math.cos(angle)
-+            y = center_y + radius * math.sin(angle)
-+            self.graph_canvas.create_line(center_x, center_y, x, y)
-+            self.graph_canvas.create_oval(x-15, y-15, x+15, y+15, fill="white")
-+            self.graph_canvas.create_text(x, y, text=adj, font=("Arial", 8))
-+
+import os
+import math
+import queue
+import tkinter as tk
+from typing import Optional
+
+
+class AvatarGUI:
+    """Minimal Tkinter interface showing glyphs, FFT images and adjacency graph."""
+
+    def __init__(self, engine) -> None:
+        self.engine = engine
+        self.root = tk.Tk()
+        self.root.title("Avatar GUI")
+        self.update_queue: queue.Queue = queue.Queue()
+        self.images: dict[str, tk.PhotoImage] = {}
+        # glyph display
+        self.glyph_label = tk.Label(self.root, text="Glyph", width=256, height=256)
+        self.glyph_label.grid(row=0, column=0, padx=5, pady=5)
+        # adjacency canvas
+        self.graph_canvas = tk.Canvas(self.root, width=256, height=256, bg="white")
+        self.graph_canvas.grid(row=0, column=1, padx=5, pady=5)
+        # audio/image FFT
+        self.audio_fft_label = tk.Label(self.root, text="Audio FFT", width=256, height=256)
+        self.audio_fft_label.grid(row=1, column=0, padx=5, pady=5)
+        self.image_fft_label = tk.Label(self.root, text="Image FFT", width=256, height=256)
+        self.image_fft_label.grid(row=1, column=1, padx=5, pady=5)
+        # gesture cue
+        self.gesture_label = tk.Label(self.root, text="Gesture: none", width=30)
+        self.gesture_label.grid(row=2, column=0, columnspan=2, pady=5)
+        self.last_token: Optional[str] = None
+
+    def run(self) -> None:
+        self.root.after(200, self.process_queue)
+        self.root.mainloop()
+
+    def process_queue(self) -> None:
+        while not self.update_queue.empty():
+            glyph, gesture = self.update_queue.get()
+            self._update_display(glyph, gesture)
+        self.root.after(200, self.process_queue)
+
+    def update_from_token(self, glyph: dict, gesture: Optional[str] = None) -> None:
+        self.update_queue.put((glyph, gesture))
+
+    def _set_image(self, label: tk.Label, path: Optional[str], key: str) -> None:
+        if path and os.path.exists(path):
+            try:
+                photo = tk.PhotoImage(file=path)
+                label.configure(image=photo, text="")
+                self.images[key] = photo
+            except Exception:
+                label.configure(text="(image error)", image="")
+        else:
+            label.configure(text="No image", image="")
+
+    def _update_display(self, glyph: dict, gesture: Optional[str]) -> None:
+        self.last_token = glyph.get("token")
+        visual = glyph.get("modalities", {}).get("visual", {})
+        audio_mod = glyph.get("modalities", {}).get("audio", {})
+        self._set_image(self.glyph_label, visual.get("symbolic_image"), "glyph")
+        self._set_image(self.audio_fft_label, audio_mod.get("fft_audio"), "audio")
+        img_fft = visual.get("fft_from_image") or visual.get("fft_visual")
+        self._set_image(self.image_fft_label, img_fft, "imgfft")
+        if gesture:
+            self.gesture_label.configure(text=f"Gesture: {gesture}")
+        else:
+            self.gesture_label.configure(text="Gesture: none")
+        self._update_graph()
+
+    def _update_graph(self) -> None:
+        self.graph_canvas.delete("all")
+        token = self.last_token
+        if not token:
+            return
+        center_x = center_y = 128
+        radius = 90
+        self.graph_canvas.create_oval(center_x-20, center_y-20, center_x+20, center_y+20, fill="lightblue")
+        self.graph_canvas.create_text(center_x, center_y, text=token)
+        adjs = list(self.engine.get_adjacencies_for_token(token).keys())[:6]
+        for i, adj in enumerate(adjs):
+            angle = math.radians(i * (360/len(adjs))) if adjs else 0
+            x = center_x + radius * math.cos(angle)
+            y = center_y + radius * math.sin(angle)
+            self.graph_canvas.create_line(center_x, center_y, x, y)
+            self.graph_canvas.create_oval(x-15, y-15, x+15, y+15, fill="white")
+            self.graph_canvas.create_text(x, y, text=adj, font=("Arial", 8))

--- a/gesture_engine.py
+++ b/gesture_engine.py
@@ -1,0 +1,25 @@
+"""Placeholder gesture display utilities."""
+
+import tkinter as tk
+
+
+_root: tk.Tk | None = None
+_label: tk.Label | None = None
+
+
+def _ensure_root() -> None:
+    global _root, _label
+    if _root is None:
+        _root = tk.Tk()
+        _root.title("Gesture")
+        _label = tk.Label(_root, text="", font=("Arial", 24))
+        _label.pack(padx=10, pady=10)
+        _root.after(100, lambda: None)  # initial update
+
+
+def display_gesture(gesture: str) -> None:
+    """Display a simple textual gesture cue."""
+    _ensure_root()
+    assert _label is not None
+    _label.config(text=gesture)
+    _root.update()

--- a/skg_engine.py
+++ b/skg_engine.py
@@ -10,6 +10,14 @@ from engine_comm import write_message, subscribe_to_stream
 from superknowledge_graph import SuperKnowledgeGraph
 from agency_gate import process_agency_gates
 from skg_thought_tracker import SKGThoughtTracker
+try:
+    from tts_engine import speak
+except Exception:
+    speak = None  # type: ignore
+try:
+    from gesture_engine import display_gesture
+except Exception:
+    display_gesture = None  # type: ignore
 
 
 class SKGEngine:
@@ -56,6 +64,7 @@ class SKGEngine:
         self.thought_tracker = SKGThoughtTracker()
         self.thought_history: List[str] = []
         self.externalized_last: bool = False
+        self.last_modality: str = "speak"
         # Runtime toggle flags controlled via the GUI
         self.speech_enabled: bool = True
         self.gesture_enabled: bool = True
@@ -279,9 +288,9 @@ class SKGEngine:
         if len(self.thought_history) > 20:
             self.thought_history = self.thought_history[-20:]
 
-        gate = self.evaluate_agency_gate(token)
+        gate, modality, _ = self.evaluate_agency_gate(token)
         if gate == "externalize":
-            self.externalize_token(token)
+            self.externalize_token(token, modality)
             self.thought_tracker.log_thought_loop(token, depth, [current_glyph], True)
             self.thought_tracker.reset()
             return [current_glyph]
@@ -295,7 +304,7 @@ class SKGEngine:
             result.extend(self.recursive_thought_loop(adj_token, depth + 1, max_depth, parent=token))
         return result
 
-    def evaluate_agency_gate(self, token: str) -> str:
+    def evaluate_agency_gate(self, token: str) -> tuple[str, str, float]:
         """
         Determine which agency gate should fire for the given token.  A simple
         heuristic is used: tokens with low weight and few adjacencies tend to
@@ -308,26 +317,32 @@ class SKGEngine:
         adj_count = len(self.adjacency_map.get(token, {}))
         token_data = {"frequency": weight, "weight": weight}
         decisions = process_agency_gates(token, token_data, adj_count)
+        modality_decision = next((d for d in decisions if d["gate"] == "expression"), {"decision": "speak", "confidence": 0.5})
         # Determine a preferred gate based on simple heuristics
         if weight <= 1 and adj_count <= 0:
-            return "explore"
+            return "explore", modality_decision["decision"], modality_decision.get("confidence", 0.5)
         if weight <= 2 and adj_count <= 2:
-            return "reevaluate"
+            return "reevaluate", modality_decision["decision"], modality_decision.get("confidence", 0.5)
         if weight >= 3:
-            return "externalize"
+            return "externalize", modality_decision["decision"], modality_decision.get("confidence", 0.5)
         # Otherwise pick the first affirmative decision or fall back to random
         for d in decisions:
             if d["decision"] == "YES":
-                return d["gate"]
-        return random.choice([d["gate"] for d in decisions])
+                return d["gate"], modality_decision["decision"], modality_decision.get("confidence", 0.5)
+        return random.choice([d["gate"] for d in decisions]), modality_decision["decision"], modality_decision.get("confidence", 0.5)
 
-    def externalize_token(self, token: str) -> None:
-        """Output a token's glyph and weight to the console."""
+    def externalize_token(self, token: str, modality: str = "speak") -> None:
+        """Output a token's glyph using speech or gesture."""
         glyph = self.token_map.get(token)
         display = glyph.get("glyph_id", glyph) if isinstance(glyph, dict) else glyph
         weight = glyph.get("modalities", {}).get("text", {}).get("weight") if isinstance(glyph, dict) else None
-        print(f"[SKGEngine] Externalizing '{token}' → '{display}' (weight: {weight if weight is not None else 'N/A'})")
+        print(f"[SKGEngine] Externalizing '{token}' → '{display}' (weight: {weight if weight is not None else 'N/A'}, modality: {modality})")
+        if modality == "speak" and speak and self.speech_enabled:
+            speak(token)
+        elif modality == "gesture" and display_gesture and self.gesture_enabled:
+            display_gesture(token)
         self.externalized_last = True
+        self.last_modality = modality
         if self.comm_enabled:
             write_message(self.comm_out_file, token, display)
 

--- a/tests/test_agency_gate.py
+++ b/tests/test_agency_gate.py
@@ -4,7 +4,12 @@ from agency_gate import process_agency_gates
 class TestAgencyGate(unittest.TestCase):
     def test_decision_structure(self):
         decisions = process_agency_gates('fire', {'frequency': 2, 'weight': 3}, adjacency_count=1)
-        self.assertTrue(all('gate' in d and 'decision' in d for d in decisions))
+        self.assertTrue(any(d['gate'] == 'expression' for d in decisions))
+        for d in decisions:
+            self.assertIn('gate', d)
+            self.assertIn('decision', d)
+            if d['gate'] == 'expression':
+                self.assertIn('confidence', d)
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_modality.py
+++ b/tests/test_modality.py
@@ -1,0 +1,33 @@
+import unittest
+from unittest.mock import patch
+import tempfile
+
+from skg_engine import SKGEngine
+
+class TestModality(unittest.TestCase):
+    def test_evaluate_agency_gate_modality(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = SKGEngine(tmp)
+            engine.token_map['wave'] = {'token': 'wave', 'modalities': {'text': {'weight': 1}}}
+            gate, modality, conf = engine.evaluate_agency_gate('wave')
+            self.assertEqual(modality, 'gesture')
+            self.assertLessEqual(conf, 0.6)
+            engine.token_map['hello'] = {'token': 'hello', 'modalities': {'text': {'weight': 4}}}
+            gate, modality, conf = engine.evaluate_agency_gate('hello')
+            self.assertEqual(modality, 'speak')
+            self.assertGreater(conf, 0.5)
+
+    def test_externalize_token_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            engine = SKGEngine(tmp)
+            with patch('skg_engine.speak') as mock_speak, patch('skg_engine.display_gesture') as mock_gesture:
+                engine.externalize_token('hi', modality='speak')
+                mock_speak.assert_called_once_with('hi')
+                mock_gesture.assert_not_called()
+                mock_speak.reset_mock()
+                engine.externalize_token('wave', modality='gesture')
+                mock_gesture.assert_called_once_with('wave')
+                mock_speak.assert_not_called()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add gesture display module and enable AvatarGUI for gesture cues
- extend agency_gate with an `expression` gate returning modality and confidence
- return modality info from `evaluate_agency_gate`
- allow `externalize_token` to speak or gesture
- document modality probabilities in README
- add tests for agency gate modalities and externalization
- fix truncated `adjacency_seed` helper

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_688bccc244d8832d8b3c14aba6bc788a