### PR TITLE
Auto-launch GUI with voice and webcam loops

### DIFF
--- a/agency_gate.py
+++ b/agency_gate.py
@@ -10,7 +10,7 @@ class AgencyGateDecision:
     confidence: float
 
 # Gate decision logic
-def process_agency_gates(token: str, token_data: dict, adjacency_count: int = 0) -> list[AgencyGateDecision]:
+def process_agency_gates(token: str, token_data: dict, adjacency_count: int = 0) -> list[dict]:
     """
     Evaluate a series of agency gates for a token.  The gates decide whether to
     explore further, reevaluate, externalize the thought or prune the branch.
@@ -35,17 +35,32 @@ def process_agency_gates(token: str, token_data: dict, adjacency_count: int = 0)
             yes_weight = 0.4 + (frequency * 0.1) + (adjacency_count * 0.05)
             explore_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[yes_weight, 0.3, 0.2])[0]
             confidence = max(0.0, min(yes_weight, 1.0))
-            decisions.append(AgencyGateDecision(gate, explore_decision, confidence))
+            decisions.append({
+                "gate": gate,
+                "decision": explore_decision,
+                "confidence": confidence,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            })
         elif gate == "reevaluate":
             yes_weight = 0.3 + (weight * 0.15) + (adjacency_count * 0.05)
             reevaluate_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[yes_weight, 0.4, 0.1])[0]
             confidence = max(0.0, min(yes_weight, 1.0))
-            decisions.append(AgencyGateDecision(gate, reevaluate_decision, confidence))
+            decisions.append({
+                "gate": gate,
+                "decision": reevaluate_decision,
+                "confidence": confidence,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            })
         elif gate == "externalize":
             yes_weight = 0.2 + (weight * 0.25) + (frequency * 0.05)
             externalize_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[yes_weight, 0.5, 0.1])[0]
             confidence = max(0.0, min(yes_weight, 1.0))
-            decisions.append(AgencyGateDecision(gate, externalize_decision, confidence))
+            decisions.append({
+                "gate": gate,
+                "decision": externalize_decision,
+                "confidence": confidence,
+                "timestamp": datetime.utcnow().isoformat() + "Z",
+            })
         elif gate == "prune":
             prune_weight = 0.6 - (weight * 0.1) - (frequency * 0.05)
             prune_decision = random.choices(["YES", "NO", "WITHHOLD"], weights=[prune_weight, 0.3, 0.1])[0]


### PR DESCRIPTION
## Summary
- update agency gate decisions to always return dictionaries so tests pass
- launch AvatarGUI automatically unless `--no-gui` is specified
- start microphone and webcam listeners on startup

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bd5d4e830832da5e5413070d691fc