### PR TITLE
Introduce AgencyGateDecision dataclass

### DIFF
--- a/tests/test_agency_gate.py
+++ b/tests/test_agency_gate.py
@@ -1,5 +1,9 @@
 import unittest
+import tempfile
+from unittest.mock import patch
+
 from agency_gate import process_agency_gates
+from skg_engine import SKGEngine, AgencyGateDecision
 
 
 class TestAgencyGate(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add an `AgencyGateDecision` dataclass
- make `evaluate_agency_gate` convert incoming decisions to the dataclass
- update tests to use patched `SKGEngine` and the dataclass

## Testing
- `python -m unittest discover -s tests -v`

------
https://chatgpt.com/codex/tasks/task_e_688c09f2fdcc832d8a11a86d6d19b500